### PR TITLE
Add compability for python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ if __name__ == '__main__':
             'fastavro',
             'matplotlib',
             'networkx',
-            'redis',
         ],
 
         setup_requires = [

--- a/xun/functions/cli.py
+++ b/xun/functions/cli.py
@@ -1,5 +1,5 @@
+from .compatibility import ast
 from pathlib import Path
-import ast
 import importlib
 import inspect
 import networkx as nx

--- a/xun/functions/compatibility/__init__.py
+++ b/xun/functions/compatibility/__init__.py
@@ -1,0 +1,1 @@
+from . import ast

--- a/xun/functions/compatibility/ast.py
+++ b/xun/functions/compatibility/ast.py
@@ -1,0 +1,382 @@
+# flake8: noqa
+"""ast
+
+This module is an attempt at backporting breaking 3.6 and 3.8 changes to older
+Python versions.
+"""
+
+
+from collections import namedtuple as _namedtuple
+import copy as _copy
+import sys as _sys
+
+
+_major_version = _sys.version_info[0]
+_minor_version = _sys.version_info[1]
+
+
+from ast import AST
+
+
+def __uninstantiable__init__(self, *args, **kwargs):
+    raise TypeError('Type {} not available'.format(type(self)))
+__uninstantiable = {'__init__': __uninstantiable__init__}
+
+
+from ast import Add
+from ast import And
+try:
+    from ast import AnnAssign
+except ImportError:
+    AnnAssign = type('AnnAssign', (AST, ), __uninstantiable)
+from ast import Assert
+from ast import Assign
+from ast import AsyncFor
+from ast import AsyncFunctionDef
+from ast import AsyncWith
+from ast import Attribute
+from ast import AugAssign
+from ast import AugLoad
+from ast import AugStore
+from ast import Await
+from ast import BinOp
+from ast import BitAnd
+from ast import BitOr
+from ast import BitXor
+from ast import BoolOp
+from ast import Break
+from ast import Bytes
+from ast import Call
+from ast import ClassDef
+from ast import Compare
+if _major_version >= 3 and _minor_version >= 8:
+    from ast import Constant
+else:
+    def _constant():
+        from ast import Num as _Num
+        from ast import Str as _Str
+        from ast import Bytes as _Bytes
+        from ast import NameConstant as _NameConstant
+        from ast import Ellipsis as _Ellipsis
+        class _ConstantMeta(type):
+            def __instancecheck__(cls, instance):
+                return cls.__subclasscheck__(cls, type(instance))
+            def __subclasscheck__(cls, other):
+                return (
+                    other is _Num or
+                    other is _Str or
+                    other is _Bytes or
+                    other is _NameConstant or
+                    other is _Ellipsis
+                )
+        class _Constant(_ConstantMeta, metaclass=_ConstantMeta):
+            """ _Constant
+
+            This class is defined using a metaclass. The reason for this is
+            that the node class ast.Constant does not exist in older Python
+            versions. However, the five node classes that exist instead of
+            ast.Constant must still count as ast.Constant classes in instance
+            checks.
+            """
+            def __new__(cls):
+                return type.__new__(cls, 'Constants', (_ConstantMeta, ), {})
+            def __init__(self):
+                pass
+            def __call__(self, value, kind=None):
+                if isinstance(value, (bool, type(None))):
+                    # bools are ints, so this should be checked first
+                    return _NameConstant(value)
+                elif isinstance(value, (int, float, complex)):
+                    return _Num(value)
+                elif isinstance(value, str):
+                    return _Str(value)
+                elif isinstance(value, bytes):
+                    return _Bytes(value)
+                elif isinstance(value, type(...)):
+                    return _Ellipsis()
+                else:
+                    raise ValueError('Unknown constant type {}'.format(value))
+        return _Constant()
+    Constant = _constant()
+from ast import Continue
+from ast import Del
+from ast import Delete
+from ast import Dict
+from ast import DictComp
+from ast import Div
+from ast import Ellipsis
+from ast import Eq
+from ast import ExceptHandler
+from ast import Expr
+from ast import Expression
+from ast import ExtSlice
+from ast import FloorDiv
+from ast import For
+try:
+    from ast import FormattedValue
+except ImportError:
+    FormattedValue = type('FormattedValue', (AST, ), __uninstantiable)
+from ast import FunctionDef
+try:
+    from ast import FunctionType
+except ImportError:
+    FunctionType = type('FunctionType', (AST, ), __uninstantiable)
+from ast import GeneratorExp
+from ast import Global
+from ast import Gt
+from ast import GtE
+from ast import If
+from ast import IfExp
+from ast import Import
+from ast import ImportFrom
+from ast import In
+from ast import Index
+from ast import Interactive
+from ast import Invert
+from ast import Is
+from ast import IsNot
+try:
+    from ast import JoinedStr
+except ImportError:
+    JoinedStr = type('JoinedStr', (AST, ), __uninstantiable)
+from ast import LShift
+from ast import Lambda
+from ast import List
+from ast import ListComp
+from ast import Load
+from ast import Lt
+from ast import LtE
+from ast import MatMult
+from ast import Mod
+from ast import Module
+from ast import Mult
+from ast import Name
+from ast import NameConstant
+try:
+    from ast import NamedExpr
+except ImportError:
+    NamedExpr = type('NamedExpr', (AST, ), __uninstantiable)
+from ast import NodeTransformer
+from ast import NodeVisitor
+from ast import Nonlocal
+from ast import Not
+from ast import NotEq
+from ast import NotIn
+from ast import Num
+from ast import Or
+from ast import Param
+from ast import Pass
+from ast import Pow
+try:
+    from ast import PyCF_ALLOW_TOP_LEVEL_AWAIT
+except ImportError:
+    PyCF_ALLOW_TOP_LEVEL_AWAIT = 8192
+from ast import PyCF_ONLY_AST
+try:
+    from ast import PyCF_TYPE_COMMENTS
+except ImportError:
+    PyCF_TYPE_COMMENTS = 4096
+from ast import RShift
+from ast import Raise
+from ast import Return
+from ast import Set
+from ast import SetComp
+from ast import Slice
+from ast import Starred
+from ast import Store
+from ast import Str
+from ast import Sub
+from ast import Subscript
+from ast import Suite
+from ast import Try
+from ast import Tuple
+try:
+    from ast import TypeIgnore
+except ImportError:
+    TypeIgnore = _namedtuple(
+        'TypeIgnore',
+        [
+            'lineno',
+            'tag',
+        ],
+    )
+from ast import UAdd
+from ast import USub
+from ast import UnaryOp
+from ast import While
+from ast import With
+from ast import Yield
+from ast import YieldFrom
+from ast import alias
+from ast import arg
+from ast import arguments
+from ast import boolop
+from ast import cmpop
+from ast import comprehension
+from ast import copy_location
+from ast import dump
+from ast import excepthandler
+from ast import expr
+from ast import expr_context
+from ast import fix_missing_locations
+from ast import get_docstring
+try:
+    from ast import get_source_segment
+except ImportError:
+    # Referenced from Python 3.8 source code
+    # https://github.com/python/cpython/blob/3.8/Lib/ast.py
+    #
+    # end_lineno and end_col_offset will always be missing in Python versions
+    # before 3.8
+    def get_source_segment(source, node, *, padded=False):
+        """Get source code segment of the *source* that generated *node*.
+        If some location information (`lineno`, `end_lineno`, `col_offset`,
+        or `end_col_offset`) is missing, return None.
+        If *padded* is `True`, the first line of a multi-line statement will
+        be padded with spaces to match its original position.
+        """
+        return None
+from ast import increment_lineno
+from ast import iter_child_nodes
+from ast import iter_fields
+from ast import keyword
+from ast import literal_eval
+from ast import mod
+from ast import operator
+if _major_version >= 3 and _minor_version >= 8:
+    from ast import parse
+else:
+    def parse(source, filename='<unknown>', mode='exec', *,
+            type_comments=False, feature_version=None):
+        """
+        Parse the source into an AST node.
+        Equivalent to compile(source, filename, mode, PyCF_ONLY_AST).
+        Pass type_comments=True to get back type comments where the syntax
+        allows.
+        """
+        if type_comments:
+            raise ValueError('type_comments was added to ast in Python 3.8')
+        if feature_version is not None:
+            raise ValueError('feature_version was added to ast in Python 3.8')
+        flags = PyCF_ONLY_AST
+        tree = compile(source, filename, mode, flags)
+        return patch_tree(tree)
+from ast import slice
+from ast import stmt
+try:
+    from ast import type_ignore
+except ImportError:
+    type_ignore = TypeIgnore
+from ast import unaryop
+from ast import walk
+from ast import withitem
+
+
+class _PatchTree(NodeTransformer):
+    def visit_arguments(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.posonlyargs
+        except AttributeError:
+            node.posonlyargs = []
+
+        return node
+
+    def visit_Module(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_ignores
+        except AttributeError:
+            node.type_ignores = []
+
+        return node
+
+    def visit_arg(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_comment
+        except AttributeError:
+            node.type_comment = None
+
+        return node
+
+    def visit_AsyncWith(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_comment
+        except AttributeError:
+            node.type_comment = None
+
+        return node
+
+    def visit_With(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_comment
+        except AttributeError:
+            node.type_comment = None
+
+        return node
+
+    def visit_AsyncFor(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_comment
+        except AttributeError:
+            node.type_comment = None
+
+        return node
+
+    def visit_For(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_comment
+        except AttributeError:
+            node.type_comment = None
+
+        return node
+
+    def visit_Assign(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_comment
+        except AttributeError:
+            node.type_comment = None
+
+        return node
+
+    def visit_AsyncFunctionDef(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_comment
+        except AttributeError:
+            node.type_comment = None
+
+        return node
+
+    def visit_FunctionDef(self, node):
+        node = self.generic_visit(node)
+
+        try:
+            node.type_comment
+        except AttributeError:
+            node.type_comment = None
+
+        return node
+
+
+def patch_tree(tree):
+    if isinstance(tree, list):
+        return [patch_tree(el) for el in tree]
+
+    tree = _copy.deepcopy(tree)
+    return _PatchTree().visit(tree)

--- a/xun/functions/function_description.py
+++ b/xun/functions/function_description.py
@@ -1,9 +1,9 @@
+from .compatibility import ast
 from .util import func_external_names
 from .util import function_ast
 from .util import function_source
 from .util import strip_decorators
 from collections import namedtuple
-import ast
 import inspect
 
 

--- a/xun/functions/transformations.py
+++ b/xun/functions/transformations.py
@@ -1,3 +1,4 @@
+from .compatibility import ast
 from .function_description import FunctionDescription
 from .function_description import describe
 from .function_image import FunctionImage
@@ -8,7 +9,6 @@ from .util import sort_constants_ast
 from .util import stmt_external_names
 from .util import stmt_introduced_names
 from itertools import chain
-import ast
 import copy
 import types
 
@@ -272,7 +272,7 @@ def copy_only_constants(
     """
     def gen_deepcopy_expr(expr):
         deepcopy_id = ast.Name(id='deepcopy', ctx=ast.Load())
-        return ast.Call(deepcopy_id, args=[expr], keywords=[])
+        return ast.Call(func=deepcopy_id, args=[expr], keywords=[])
 
     class CallArgumentCopyTransformer(ast.NodeTransformer):
         def visit_Call(self, node):

--- a/xun/functions/transformations.py
+++ b/xun/functions/transformations.py
@@ -1,3 +1,17 @@
+"""Transformations
+
+This module includes functionality for working with and manipulating function
+code. The FunctionDecomposition class provides a data structure to make
+managing code fragments easier, while the transformation functions are used to
+generate xun scheduling and execution code.
+
+The code is represented by and manipulated with the python ast module [1][2].
+
+.. [1] Python ast documentation: https://docs.python.org/3/library/ast.html
+.. [2] Greentreesnakes: https://greentreesnakes.readthedocs.io/en/latest/
+"""
+
+
 from .compatibility import ast
 from .function_description import FunctionDescription
 from .function_description import describe
@@ -11,20 +25,6 @@ from .util import stmt_introduced_names
 from itertools import chain
 import copy
 import types
-
-
-"""Transformations
-
-This module includes functionality for working with and manipulating function
-code. The FunctionDecomposition class provides a data structure to make managing
-code fragments easier, while the transformation functions are used to generate
-xun scheduling and execution code.
-
-The code is represented by and manipulated with the python ast module [1][2].
-
-.. [1] Python ast documentation: https://docs.python.org/3/library/ast.html
-.. [2] Greentreesnakes: https://greentreesnakes.readthedocs.io/en/latest/
-"""
 
 
 class FunctionDecomposition(types.SimpleNamespace):

--- a/xun/functions/util.py
+++ b/xun/functions/util.py
@@ -1,8 +1,8 @@
+from .compatibility import ast
 from .errors import NotDAGError
 from collections import Counter
 from itertools import chain
 from itertools import tee
-import ast
 import copy
 import inspect
 import networkx as nx
@@ -353,7 +353,6 @@ def func_arg_names(fdef):
     CollectArgs().visit(fdef)
 
     return frozenset(args)
-
 
 
 #

--- a/xun/tests/helpers.py
+++ b/xun/tests/helpers.py
@@ -1,6 +1,6 @@
 from io import StringIO
 from itertools import starmap
-import ast
+from xun.functions.compatibility import ast
 import sys
 import xun
 
@@ -43,7 +43,7 @@ class PickleDriver(xun.functions.driver.Sequential):
 
 def compare_ast(a, b):
     def is_relevant(node, k, v):
-        ignored_keys=(
+        ignored_keys = (
             'col_offset',
             'ctx',
             'end_col_offset',

--- a/xun/tests/test_compatibility.py
+++ b/xun/tests/test_compatibility.py
@@ -1,0 +1,45 @@
+from xun.functions.compatibility import ast as compat_ast
+import ast
+import sys
+
+
+major_version = sys.version_info[0]
+minor_version = sys.version_info[1]
+
+
+def test_Constant():
+    constant_int = compat_ast.Constant(5)
+    constant_float = compat_ast.Constant(5.5)
+    constant_complex = compat_ast.Constant(5.5 + 5j)
+    constant_string = compat_ast.Constant("hello")
+    constant_bytes = compat_ast.Constant(b"0042")
+    constant_nameconstant_bool = compat_ast.Constant(True)
+    constant_nameconstant_none = compat_ast.Constant(None)
+    constant_ellipsis = compat_ast.Constant(...)
+
+    assert isinstance(constant_int, compat_ast.Constant)
+    assert isinstance(constant_float, compat_ast.Constant)
+    assert isinstance(constant_complex, compat_ast.Constant)
+    assert isinstance(constant_string, compat_ast.Constant)
+    assert isinstance(constant_bytes, compat_ast.Constant)
+    assert isinstance(constant_nameconstant_bool, compat_ast.Constant)
+    assert isinstance(constant_nameconstant_none, compat_ast.Constant)
+    assert isinstance(constant_ellipsis, compat_ast.Constant)
+
+    if major_version >= 3 and minor_version >= 8:
+        assert compat_ast.Constant is ast.Constant
+    else:
+        assert type(constant_int) is ast.Num
+        assert type(constant_float) is ast.Num
+        assert type(constant_complex) is ast.Num
+        assert type(constant_string) is ast.Str
+        assert type(constant_bytes) is ast.Bytes
+        assert type(constant_nameconstant_bool) is ast.NameConstant
+        assert type(constant_nameconstant_none) is ast.NameConstant
+        assert type(constant_ellipsis) is ast.Ellipsis
+
+
+def test_parse_patch():
+    tree = compat_ast.parse('def f(): pass')
+    assert hasattr(tree, 'type_ignores')
+    assert hasattr(tree.body[0], 'type_comment')

--- a/xun/tests/test_transformations.py
+++ b/xun/tests/test_transformations.py
@@ -1,6 +1,6 @@
 from .helpers import compare_ast
 from typing import List
-import ast
+from xun.functions.compatibility import ast
 import astor
 import pytest
 import networkx as nx


### PR DESCRIPTION
The implementation of the ast module has changed from Python 3.7
to 3.8, so a separate module is added here to deal with that.

The main changes are related to differences in the argument list
for the different ast objects.

Resolves #31 