### PR TITLE
Fix missing ast attributes

### DIFF
--- a/xun/functions/cli.py
+++ b/xun/functions/cli.py
@@ -104,18 +104,22 @@ def interpret_call(call_string):
     if not isinstance(call.func, ast.Name):
         raise SyntaxError('Call must be to a named function')
 
-    keywords = {ast.Constant(value=kw.arg): kw.value for kw in call.keywords}
+    keywords = {
+        ast.Constant(value=kw.arg, kind=None): kw.value for kw in call.keywords
+    }
 
     module = ast.fix_missing_locations(ast.Module(
         type_ignores=[],
         body=[
             ast.Assign(
                 targets=[ast.Name(id='function_name', ctx=ast.Store())],
-                value=ast.Constant(value=call.func.id),
+                value=ast.Constant(value=call.func.id, kind=None),
+                type_comment=None,
             ),
             ast.Assign(
                 targets=[ast.Name(id='args', ctx=ast.Store())],
                 value=ast.List(elts=call.args, ctx=ast.Load()),
+                type_comment=None,
             ),
             ast.Assign(
                 targets=[ast.Name(id='kwargs', ctx=ast.Store())],
@@ -123,6 +127,7 @@ def interpret_call(call_string):
                     keys=list(keywords.keys()),
                     values=list(keywords.values()),
                 ),
+                type_comment=None,
             ),
         ],
     ))

--- a/xun/functions/transformations.py
+++ b/xun/functions/transformations.py
@@ -155,6 +155,8 @@ class FunctionDecomposition(types.SimpleNamespace):
                     args=args,
                     decorator_list=[],
                     body=body,
+                    returns=None,
+                    type_comment=None,
                 )
             ],
         ))
@@ -298,7 +300,8 @@ def copy_only_constants(
 
     from_copy_import_deepcopy = ast.ImportFrom(
         module='copy',
-        names=[ast.alias(name='deepcopy')],
+        names=[ast.alias(name='deepcopy', asname=None)],
+        level=0
     )
     copy_only_constants = [from_copy_import_deepcopy, *transformed]
 
@@ -380,7 +383,7 @@ def build_xun_graph(
             The list of strings as a list of strings expression
         """
         expr = ast.List(
-            elts=[ast.Constant(el) for el in L],
+            elts=[ast.Constant(value=el, kind=None) for el in L],
             ctx=ast.Load(),
         )
         return expr
@@ -406,7 +409,7 @@ def build_xun_graph(
             new_node = ast.Call(
                 func=ast.Name(id='_xun_register_future_value', ctx=ast.Load()),
                 args=[
-                    ast.Constant(node.func.id),
+                    ast.Constant(value=node.func.id, kind=None),
                     str_list_to_ast(self.external_xun_names),
                     str_list_to_ast(self.targets),
                     *node.args
@@ -506,7 +509,7 @@ def load_from_store(
 
             construct_call = ast.Call(
                 func=ast.Name(id='_xun_CallNode', ctx=ast.Load()),
-                args=[ast.Constant(node.func.id), *node.args],
+                args=[ast.Constant(value=node.func.id, kind=None), *node.args],
                 keywords=node.keywords,
             )
 
@@ -571,6 +574,7 @@ def load_from_store(
                     asname='_xun_CallNode'
                 ),
             ],
+            level=0,
         ),
         ast.ImportFrom(
             module='xun.functions',
@@ -580,6 +584,7 @@ def load_from_store(
                     asname='_xun_FutureValueNode'
                 ),
             ],
+            level=0
         ),
     ]
 
@@ -602,6 +607,8 @@ def load_from_store(
             )
         ],
         decorator_list=[],
+        returns=None,
+        type_comment=None,
     )
 
     load_call = ast.Assign(
@@ -618,6 +625,7 @@ def load_from_store(
             args=[],
             keywords=[],
         ),
+        type_comment=None,
     )
 
     lfs = [

--- a/xun/tests/helpers.py
+++ b/xun/tests/helpers.py
@@ -82,29 +82,21 @@ class FakeRedis(xun.functions.store.Redis):
 
 
 def compare_ast(a, b):
-    def is_relevant(node, k, v):
+    def is_relevant(node, k):
         ignored_keys = (
             'col_offset',
-            'ctx',
             'end_col_offset',
             'end_lineno',
             'lineno',
         )
-
-        if k.startswith('_'):
-            return False
-
-        if isinstance(node, ast.ImportFrom) and k == 'level':
-            return v != 0
-
-        return k not in ignored_keys and v is not None
+        return k not in ignored_keys
 
     if type(a) is not type(b):
         return False
 
     if isinstance(a, ast.AST):
-        a_attrs = {k: v for k, v in vars(a).items() if is_relevant(a, k, v)}
-        b_attrs = {k: v for k, v in vars(b).items() if is_relevant(b, k, v)}
+        a_attrs = {k: v for k, v in vars(a).items() if is_relevant(a, k)}
+        b_attrs = {k: v for k, v in vars(b).items() if is_relevant(b, k)}
 
         if set(a_attrs.keys()) != set(b_attrs.keys()):
             return False

--- a/xun/tests/test_compatibility.py
+++ b/xun/tests/test_compatibility.py
@@ -8,14 +8,14 @@ minor_version = sys.version_info[1]
 
 
 def test_Constant():
-    constant_int = compat_ast.Constant(5)
-    constant_float = compat_ast.Constant(5.5)
-    constant_complex = compat_ast.Constant(5.5 + 5j)
-    constant_string = compat_ast.Constant("hello")
-    constant_bytes = compat_ast.Constant(b"0042")
-    constant_nameconstant_bool = compat_ast.Constant(True)
-    constant_nameconstant_none = compat_ast.Constant(None)
-    constant_ellipsis = compat_ast.Constant(...)
+    constant_int = compat_ast.Constant(5, None)
+    constant_float = compat_ast.Constant(5.5, None)
+    constant_complex = compat_ast.Constant(5.5 + 5j, None)
+    constant_string = compat_ast.Constant("hello", None)
+    constant_bytes = compat_ast.Constant(b"0042", None)
+    constant_nameconstant_bool = compat_ast.Constant(True, None)
+    constant_nameconstant_none = compat_ast.Constant(None, None)
+    constant_ellipsis = compat_ast.Constant(..., None)
 
     assert isinstance(constant_int, compat_ast.Constant)
     assert isinstance(constant_float, compat_ast.Constant)

--- a/xun/tests/test_transformations.py
+++ b/xun/tests/test_transformations.py
@@ -238,3 +238,21 @@ def test_dependency_without_target():
         store=xun.functions.store.Memory(),
     )
     assert result == 1
+
+
+def test_xun_function_to_source():
+    @xun.function()
+    def f(a='a'):
+        return a*2
+
+    @xun.function()
+    def g():
+        with ...:
+            a = f()
+            b = f(a)
+            c = f(b)
+        value = a + c
+        return value
+
+    tree = g.callable().tree
+    assert isinstance(astor.to_source(tree), str)


### PR DESCRIPTION
Some of the attributes in the ast nodes are noted with an '?' in
the grammar [(1)](https://docs.python.org/3.8/library/ast.html).
It turns out in this context the attributes are not optional, but
'nullable'. This commit adds the missing 'nullable' attributes to
the relevant ast nodes.