### PR TITLE
Make function hashes part of CallNodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
             python -m pip install cmake scikit-build pybind11
             python -m pip install -r requirements-dev.txt
             python -m pip install -r requirements.txt
-            
+
       - run:
           name: Test python
           command: |
@@ -89,7 +89,7 @@ commands:
       - run:
           name: Check formatting rules (PEP8)
           command: |
-            git diff HEAD^ | flake8 --diff --per-file-ignores="__init__.py:F401" --exclude="setup.py"
+            git diff origin/master | flake8 --diff --per-file-ignores="__init__.py:F401" --exclude="setup.py"
 
   bandit-check:
     steps:

--- a/xun/functions/blueprint.py
+++ b/xun/functions/blueprint.py
@@ -24,7 +24,7 @@ class Blueprint:
     """
 
     def __init__(self, func, *args, **kwargs):
-        self.call = CallNode(func.name, *args, **kwargs)
+        self.call = func.callnode(*args, **kwargs)
         self.functions = discover_functions(func)
         self.graph = build_call_graph(self.functions, self.call)
 

--- a/xun/functions/driver/celery.py
+++ b/xun/functions/driver/celery.py
@@ -129,7 +129,7 @@ class AsyncCeleryState:
 
             func = self.function_images[node.function_name]
 
-            if self.store_accessor.completed(node, func.hash):
+            if self.store_accessor.completed(node):
                 logger.info('{} already completed'.format(node))
             else:
                 logger.info('Submitting {}'.format(node))
@@ -203,7 +203,7 @@ def celery_xun_exec(call, func, store_accessor):
 
     args, kwargs = store_accessor.resolve_call_args(call)
     result = func(*args, **kwargs)
-    store_accessor.store_result(call, func.hash, result)
+    store_accessor.store_result(call, result)
 
     logger.info('{} succeeded'.format(call))
     return 0

--- a/xun/functions/driver/dask.py
+++ b/xun/functions/driver/dask.py
@@ -11,7 +11,7 @@ class DaskDriverError(Exception):
 
 
 def compute_proxy(node, dependencies, func, store_accessor):
-    if store_accessor.completed(node, func.hash):
+    if store_accessor.completed(node):
         return store_accessor.load_result(node)
 
     args, kwargs = store_accessor.resolve_call_args(node)
@@ -21,7 +21,7 @@ def compute_proxy(node, dependencies, func, store_accessor):
         raise DaskDriverError(f'task {node} failed') from e
     except:
         raise ValueError('???')
-    store_accessor.store_result(node, func.hash, result)
+    store_accessor.store_result(node, result)
     return node
 
 

--- a/xun/functions/driver/driver.py
+++ b/xun/functions/driver/driver.py
@@ -14,9 +14,8 @@ class Driver(ABC):
         pass
 
     def exec(self, graph, entry_call, function_images, store_accessor):
-        entry_hash = function_images[entry_call.function_name].hash
         self._exec(graph, entry_call, function_images, store_accessor)
-        return store_accessor.client.load_result(entry_call, hash=entry_hash)
+        return store_accessor.client.load_result(entry_call)
 
     def __call__(self, graph, entry_call, function_images, store_accessor):
         return self.exec(graph, entry_call, function_images, store_accessor)

--- a/xun/functions/driver/sequential.py
+++ b/xun/functions/driver/sequential.py
@@ -15,7 +15,7 @@ class Sequential(Driver):
     def run_and_store(self, call, func, store_accessor):
         args, kwargs = store_accessor.resolve_call_args(call)
         result = func(*args, **kwargs)
-        store_accessor.store_result(call, func.hash, result)
+        store_accessor.store_result(call, result)
 
     def _exec(self, graph, entry_call, function_images, store_accessor):
         assert nx.is_directed_acyclic_graph(graph)
@@ -30,7 +30,7 @@ class Sequential(Driver):
 
             # Do not rerun finished jobs. For example if a workflow has been
             # stopped and resumed.
-            if store_accessor.completed(node, func.hash):
+            if store_accessor.completed(node):
                 logger.info('{} already completed'.format(node))
                 continue
 

--- a/xun/functions/function.py
+++ b/xun/functions/function.py
@@ -1,5 +1,6 @@
 from .blueprint import Blueprint
 from .function_description import describe
+from .graph import CallNode
 from . import transformations
 import hashlib
 import astor
@@ -176,6 +177,27 @@ class Function:
         Blueprint : Comprises the call, call graph, and required functions
         """
         return Blueprint(self, *args, **kwargs)
+
+    def callnode(self, *args, **kwargs):
+        """Call Node
+
+        Create a CallNode for a call to this function
+
+        Parameters
+        ----------
+        *args
+        **kwargs
+
+        Returns
+        -------
+        CallNode
+            CallNode representing a call to this function
+
+        See Also
+        --------
+        CallNode : Symbolic representation of a call to this function
+        """
+        return CallNode(self.name, self.hash, *args, **kwargs)
 
     def createGraphBuilder(self):
         """CreateGraphBuilder

--- a/xun/functions/graph.py
+++ b/xun/functions/graph.py
@@ -38,13 +38,16 @@ class CallNode:
     ----------
     function_name : str
         name of the function this representation is a call to
+    function_hash : bytes
+        SHA256 identifier of the function
     args : lists of arguments
         the arguments of this call
     kwargs : mapping of str to arguments
         the keyword arguments of this call
     """
-    def __init__(self, function_name, *args, **kwargs):
+    def __init__(self, function_name, function_hash, *args, **kwargs):
         self.function_name = function_name
+        self.function_hash = function_hash
         self.subscript = ()
         self.args = args
         self.kwargs = kwargs
@@ -61,6 +64,7 @@ class CallNode:
     def __eq__(self, other):
         try:
             return (self.function_name == other.function_name
+                and self.function_hash == other.function_hash
                 and self.subscript == other.subscript
                 and self.args == other.args
                 and self.kwargs == other.kwargs)
@@ -70,22 +74,22 @@ class CallNode:
     def __hash__(self):
         return hash((
             self.function_name,
+            self.function_hash,
             self.subscript,
             tuple(self.args),
             frozenset(self.kwargs.items())
         ))
 
     def __repr__(self):
-        args = [repr(self.function_name)]
-        if len(self.subscript) > 0:
-            args.append(str(self.subscript))
+        args = [repr(self.function_name), repr(self.function_hash)]
         if len(self.args) > 0:
             args.append(', '.join(repr(a) for a in self.args))
         if len(self.kwargs) > 0:
             args.append(', '.join(
                 '{}={}'.format(k, repr(v)) for k, v in self.kwargs.items()
             ))
-        return 'CallNode({})'.format(', '.join(args))
+        subscript = ''.join(f'[{s}]' for s in self.subscript)
+        return f'CallNode({", ".join(args)}){subscript}'
 
     def _replace(self, **kwargs):
         """

--- a/xun/functions/store/store_accessor.py
+++ b/xun/functions/store/store_accessor.py
@@ -16,15 +16,13 @@ class StoreAccessor:
 
     Methods
     -------
-    load_result(call, hash=None)
-        Loads a result for a call, use hash to specify a specific function
-        version
-    store_result(call, hash, result)
-        Stores a result for a call and function hash. The latest reference is
-        updated to point to this result
-    completed(call, hash=None)
-        True if there is a value stored for a given call. If hash is not
-        supplied, we check against the latest stored result.
+    load_result(call)
+        Loads a result for a call
+    store_result(call, result)
+        Stores a result for a call. The latest reference is updated to point to
+        this result
+    completed(call)
+        True if there is a value stored for a given call.
     """
 
     def __init__(self, store, client_store=None):
@@ -38,27 +36,18 @@ class StoreAccessor:
         else:
             return self
 
-    def load_result(self, call, hash=None):
+    def load_result(self, call):
         namespace = self.store / 'results' / call
-        hash = hash if hash is not None else namespace['latest']
-        return namespace[hash]
+        return namespace[call.function_hash]
 
-    def store_result(self, call, hash, result):
+    def store_result(self, call, result):
         namespace = self.store / 'results' / call
-        namespace[hash] = result
-        namespace['latest'] = hash
+        namespace[call.function_hash] = result
+        namespace['latest'] = call.function_hash
 
-    def completed(self, call, hash=None):
+    def completed(self, call):
         namespace = self.store / 'results' / call
-
-        if hash is not None:
-            return hash in namespace
-
-        if 'latest' in namespace:
-            hash = namespace['latest']
-            return hash in namespace
-
-        return False
+        return call.function_hash in namespace
 
     def resolve_call_args(self, call):
         """

--- a/xun/tests/test_celery_driver.py
+++ b/xun/tests/test_celery_driver.py
@@ -1,5 +1,4 @@
 from .helpers import PicklableMemoryStore
-from xun.functions import CallNode
 import gc
 import threading
 import time
@@ -99,7 +98,7 @@ def test_celery_concurrency(xun_celery_worker):
             ) and obj.visited == {
                 # There might be more than one state object alive, so we need
                 # to identify ours
-                CallNode('a')
+                a.callnode()
             }:
             acs = obj
 
@@ -111,18 +110,18 @@ def test_celery_concurrency(xun_celery_worker):
     # If the b _and_ c are visited, the program is concurrent.
     waited = 0.0
     while acs.visited != {
-            CallNode('a'),
-            CallNode('b'),
-            CallNode('c'),
+            a.callnode(),
+            b.callnode(),
+            c.callnode(),
         } and waited < 10.0:
         time.sleep(0.01)
         waited += 0.01
 
     # d should be the only node left unvisited
     assert acs.visited == {
-            CallNode('a'),
-            CallNode('b'),
-            CallNode('c'),
+            a.callnode(),
+            b.callnode(),
+            c.callnode(),
         }
 
     # Let b and c complete, d should then finish

--- a/xun/tests/test_data/script.py
+++ b/xun/tests/test_data/script.py
@@ -16,3 +16,13 @@ def hello_world(receiver):
     return '{} {}!'.format(a, receiver)
     with ...:
         a = hello()
+
+
+@xun.function()
+def f(*args, **kwargs):
+    pass
+
+
+@xun.function()
+def g(*args, **kwargs):
+    pass

--- a/xun/tests/test_functions_cli.py
+++ b/xun/tests/test_functions_cli.py
@@ -1,38 +1,40 @@
-from xun.functions import CallNode
 from xun.functions import cli
 from xun import XunSyntaxError
 import pytest
 
 
-def test_interpret_call():
-    no_args = cli.interpret_call('f()')
-    args_only = cli.interpret_call('f(1, 2, 3)')
-    kwargs_only = cli.interpret_call('f(x="x", y="y", z="z")')
-    args_kwargs = cli.interpret_call('f(1, 2, 3, x="x", y="y", z="z")')
+module = cli.load_module('xun/tests/test_data/script.py')
 
-    assert no_args == CallNode('f')
-    assert args_only == CallNode('f', 1, 2, 3)
-    assert kwargs_only == CallNode('f', x='x', y='y', z='z')
-    assert args_kwargs == CallNode('f', 1, 2, 3, x='x', y="y", z="z")
+
+def test_interpret_call():
+    no_args = cli.interpret_call('f()', module)
+    args_only = cli.interpret_call('f(1, 2, 3)', module)
+    kwargs_only = cli.interpret_call('f(x="x", y="y", z="z")', module)
+    args_kwargs = cli.interpret_call('f(1, 2, 3, x="x", y="y", z="z")', module)
+
+    assert no_args == module.f.callnode()
+    assert args_only == module.f.callnode(1, 2, 3)
+    assert kwargs_only == module.f.callnode(x='x', y='y', z='z')
+    assert args_kwargs == module.f.callnode(1, 2, 3, x='x', y="y", z="z")
 
 
 def test_interpret_call_expression():
-    call = cli.interpret_call('f(1 + 2)')
-    assert call == CallNode('f', 3)
+    call = cli.interpret_call('f(1 + 2)', module)
+    assert call == module.f.callnode(3)
 
 
 def test_syntax_errors():
     with pytest.raises(SyntaxError):
-        cli.interpret_call('invalid code')
+        cli.interpret_call('invalid code', module)
 
     with pytest.raises(XunSyntaxError):
-        cli.interpret_call('f(); g()')
+        cli.interpret_call('f(); g()', module)
 
     with pytest.raises(XunSyntaxError):
-        cli.interpret_call('for i in range(5): f(i)')
+        cli.interpret_call('for i in range(5): f(i)', module)
 
     with pytest.raises(XunSyntaxError):
-        cli.interpret_call('1 + 1')
+        cli.interpret_call('1 + 1', module)
 
     with pytest.raises(XunSyntaxError):
-        cli.interpret_call('(1 + 1)()')
+        cli.interpret_call('(1 + 1)()', module)

--- a/xun/tests/test_graph.py
+++ b/xun/tests/test_graph.py
@@ -2,7 +2,7 @@ from xun.functions.graph import CallNode
 
 
 def test_unpack():
-    cn = CallNode('f')
+    cn = CallNode('f', None)
 
     assert cn[0] == cn[0]
     assert not cn[0] == cn[1]
@@ -85,7 +85,7 @@ def test_unpack():
 
 
 def test_unpack_starred():
-    cn = CallNode('f')
+    cn = CallNode('f', None)
 
     shape = (2, Ellipsis)
     a = cn.unpack(shape)

--- a/xun/tests/test_transformations.py
+++ b/xun/tests/test_transformations.py
@@ -128,12 +128,12 @@ def test_load_from_store_transformation():
             from xun.functions import CallNode as _xun_CallNode
             from xun.functions.store import StoreAccessor as _xun_StoreAccessor
             _xun_store_accessor = _xun_StoreAccessor(_xun_store)
-            a = _xun_CallNode('f')
-            b = _xun_CallNode('f', a)
-            c = _xun_CallNode('f', b)
+            a = _xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a')
+            b = _xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a', a)
+            c = _xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a', b)
             return (
-                _xun_store_accessor.load_result(_xun_CallNode('f'), hash=b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a'),
-                _xun_store_accessor.load_result(_xun_CallNode('f', b), hash=b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a'),
+                _xun_store_accessor.load_result(_xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a')),
+                _xun_store_accessor.load_result(_xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a', b)),
             )
         a, c = _xun_load_constants()
         value = a + c
@@ -294,12 +294,12 @@ def test_structured_unpacking_transformation():
             from xun.functions import CallNode as _xun_CallNode
             from xun.functions.store import StoreAccessor as _xun_StoreAccessor
             _xun_store_accessor = _xun_StoreAccessor(_xun_store)
-            a, b, ((x, y, z), (𝛂, β)), c, d = _xun_CallNode('f').unpack(
+            a, b, ((x, y, z), (𝛂, β)), c, d = _xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a').unpack(
                 (2, ((3,), (2,)), 2))
-            something = _xun_CallNode('h', x, y, z)
+            something = _xun_CallNode('h', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a', x, y, z)
             return (
-                _xun_store_accessor.load_result(_xun_CallNode('f'), hash=b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a'),
-                _xun_store_accessor.load_result(_xun_CallNode('h', x, y, z), hash=b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a'),
+                _xun_store_accessor.load_result(_xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a')),
+                _xun_store_accessor.load_result(_xun_CallNode('h', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a', x, y, z)),
             )
         (a, b, ((x, y, z), (𝛂, β)), c, d), something = _xun_load_constants()
         return a * b * x * y * z * 𝛂 * β * c * d + something
@@ -340,11 +340,11 @@ def test_unreferenced_names_are_not_loaded():
             from xun.functions import CallNode as _xun_CallNode
             from xun.functions.store import StoreAccessor as _xun_StoreAccessor
             _xun_store_accessor = _xun_StoreAccessor(_xun_store)
-            a = _xun_CallNode('f')
-            b = _xun_CallNode('h', a)
-            c = _xun_CallNode('g', b)
-            return (_xun_store_accessor.load_result(_xun_CallNode('f'), hash=b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a'),
-                    _xun_store_accessor.load_result(_xun_CallNode('g', b), hash=b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a'),
+            a = _xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a')
+            b = _xun_CallNode('h', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a', a)
+            c = _xun_CallNode('g', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a', b)
+            return (_xun_store_accessor.load_result(_xun_CallNode('f', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a')),
+                    _xun_store_accessor.load_result(_xun_CallNode('g', b'+\xd6n\xc40\xf9\xc7\xa6\xad.C]\xbc\x98\x99\x1c\x8b\xebj\xef\xd3\x82*\x8a\xa0\xe4\xc7\x1b\xf7\xc3\xbe\x8a', b)),
             )
         a, c = _xun_load_constants()
         return a + c


### PR DESCRIPTION
Before this change, if the code creating a value was changed, it would
not trigger rerunning of any calls dependent on that value. This is
because it was reference to in the store with name only.