### PR TITLE
Virtual results

### DIFF
--- a/xun/functions/__init__.py
+++ b/xun/functions/__init__.py
@@ -6,6 +6,7 @@ from .errors import FunctionError
 from .errors import FunctionDefNotFoundError
 from .errors import NotDAGError
 from .errors import XunSyntaxError
+from .errors import XunInterfaceError
 from .function import Function
 from .function import function
 from .function_description import FunctionDescription

--- a/xun/functions/blueprint.py
+++ b/xun/functions/blueprint.py
@@ -59,14 +59,14 @@ class Blueprint:
             # The callable functions_images of the necessary xun functions
             # _must_ be picklable
             pickle.loads(pickle.dumps({
-                name: func.callable()
+                name: func.callable
                 for name, func in self.functions.items()
             }))
             if not isinstance(store, Memory):
                 pickle.loads(pickle.dumps(store))
 
         function_images = {
-            name: func.callable(extra_globals={'_xun_store': store})
+            name: func.callable
             for name, func in self.functions.items()
         }
 

--- a/xun/functions/driver/dask.py
+++ b/xun/functions/driver/dask.py
@@ -27,11 +27,8 @@ def compute_proxy(store_accessor, func):
     """Dask 'handles' functools.partial so that we can't use it. Create a new
        function instead."""
     def λ(node):
-        args, kwargs = store_accessor.resolve_call_args(node)
-        result = func(*args, **kwargs)
-        store_accessor.store_result(node, result)
-        return node
-    functools.update_wrapper(λ,  func)
+        return Driver.compute_and_store(node, func, store_accessor)
+    functools.update_wrapper(λ, func)
     return λ
 
 

--- a/xun/functions/driver/driver.py
+++ b/xun/functions/driver/driver.py
@@ -1,5 +1,9 @@
 from abc import ABC
 from abc import abstractmethod
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class Driver(ABC):
@@ -14,8 +18,25 @@ class Driver(ABC):
         pass
 
     def exec(self, graph, entry_call, function_images, store_accessor):
-        self._exec(graph, entry_call, function_images, store_accessor)
+        guarded_store_accessor = store_accessor.guarded()
+        self._exec(graph, entry_call, function_images, guarded_store_accessor)
         return store_accessor.client.load_result(entry_call)
 
     def __call__(self, graph, entry_call, function_images, store_accessor):
         return self.exec(graph, entry_call, function_images, store_accessor)
+
+    @staticmethod
+    def compute_and_store(callnode, func, store_accessor):
+        args, kwargs = store_accessor.resolve_call_args(callnode)
+        results = func(*args, **kwargs)
+        results.send(None)
+        results.send(store_accessor)
+        while True:
+            try:
+                result_call, result = next(results)
+                logger.debug(f'Storing result for {result_call}')
+                store_accessor.store_result(result_call, result)
+            except StopIteration as result:
+                logger.debug(f'Storing result for {callnode}')
+                store_accessor.store_result(callnode, result.value)
+                return result.value

--- a/xun/functions/driver/sequential.py
+++ b/xun/functions/driver/sequential.py
@@ -12,11 +12,6 @@ class Sequential(Driver):
     Does a topological sort of the graph, and runs the jobs sequentially
     """
 
-    def run_and_store(self, call, func, store_accessor):
-        args, kwargs = store_accessor.resolve_call_args(call)
-        result = func(*args, **kwargs)
-        store_accessor.store_result(call, result)
-
     def _exec(self, graph, entry_call, function_images, store_accessor):
         assert nx.is_directed_acyclic_graph(graph)
 
@@ -36,7 +31,7 @@ class Sequential(Driver):
 
             logger.info('Running {}'.format(node))
             try:
-                self.run_and_store(node, func, store_accessor)
+                self.compute_and_store(node, func, store_accessor)
             except Exception as e:
                 logger.error(
                     '{} failed with {}'.format(node, str(e))

--- a/xun/functions/errors.py
+++ b/xun/functions/errors.py
@@ -18,5 +18,9 @@ class NotDAGError(Exception):
     pass
 
 
+class XunInterfaceError(Exception):
+    pass
+
+
 class XunSyntaxError(Exception):
     pass

--- a/xun/functions/function_image.py
+++ b/xun/functions/function_image.py
@@ -1,4 +1,5 @@
 from .function_description import describe
+from .util import overwrite_scope
 import functools
 import importlib
 
@@ -143,7 +144,7 @@ class FunctionImage:
         """
         function_code = compile(self.tree, '<ast>', 'exec')
 
-        namespace = {
+        globals = {
             '__builtins__': __builtins__,
             **self.globals,
             **{
@@ -151,8 +152,10 @@ class FunctionImage:
                 for m in self.referenced_modules
             },
         }
+        namespace = {}
         exec(function_code, namespace)  # nosec
         f = namespace[self.name]
+        f = overwrite_scope(f, globals, module=self.__module__)
 
         functools.update_wrapper(f, self)
 
@@ -203,6 +206,9 @@ class FunctionImage:
         self.referenced_modules = state[7]
         self.hash = state[8]
         self._func = None
+
+    def __repr__(self):
+        return f'<FunctionImage: {self.__name__} #{self.hash}>'
 
 
 def make_shared(func):

--- a/xun/functions/util.py
+++ b/xun/functions/util.py
@@ -648,3 +648,40 @@ def make_hashable(a):
         return a
     else:
         raise TypeError(f'unhashable type {a.__class__}')
+
+
+def call_from_function_definition(f_def):
+    f_name = ast.Name(id=f_def.name, ctx=ast.Load())
+
+    f_args = []
+    for arg in f_def.args.posonlyargs:
+        f_args.append(ast.Name(id=arg.arg, ctx=ast.Load()))
+
+    for arg in f_def.args.args:
+        f_args.append(ast.Name(id=arg.arg, ctx=ast.Load()))
+
+    if f_def.args.vararg is not None:
+        f_args.append(
+            ast.Starred(
+                value=ast.Name(id=f_def.args.vararg.arg, ctx=ast.Load()),
+                ctx=ast.Load(),
+            )
+        )
+
+    for arg in f_def.args.kwonlyargs:
+        f_args.append(ast.Name(id=arg.arg, ctx=ast.Load()))
+
+    f_keywords = []
+    if f_def.args.kwarg is not None:
+        f_keywords.append(
+            ast.keyword(
+                arg=None,
+                value=ast.Name(id=f_def.args.kwarg.arg, ctx=ast.Load()),
+            )
+        )
+
+    return ast.Call(
+        func=f_name,
+        args=f_args,
+        keywords=f_keywords,
+    )

--- a/xun/tests/test_transformations.py
+++ b/xun/tests/test_transformations.py
@@ -125,15 +125,14 @@ def test_load_from_store_transformation():
 
     @xun.function_ast
     def reference_source():
+        _xun_store_accessor = yield
+        yield
         def _xun_load_constants():
-            from xun.functions import unpack as _xun_unpack
+            from xun.functions import unpack as _xun_unpack  # noqa: F401
             from copy import deepcopy as _xun_deepcopy  # noqa: F401
-            from xun.functions import CallNode as _xun_CallNode
-            from xun.functions.store import StoreAccessor as _xun_StoreAccessor
-            _xun_store_accessor = _xun_StoreAccessor(_xun_store)
-            a = _xun_CallNode('f', 'K9ZuxDD5x6atLkNd')
-            b = _xun_CallNode('h', 'K9ZuxDD5x6atLkNd', a)
-            c = _xun_CallNode('g', 'K9ZuxDD5x6atLkNd', b)
+            a = f()
+            b = h(a)
+            c = g(b)
             return _xun_store_accessor.deepload(a, c)
         a, c = _xun_load_constants()
         value = a + c
@@ -145,13 +144,14 @@ def test_load_from_store_transformation():
         pass
     known_functions = {'f': dummy, 'h': dummy, 'g': dummy}
 
+    head = xform.generate_header()
     body, constants = xform.separate_constants(desc)
     sorted_constants, _ = xform.sort_constants(constants)
     copy_only = xform.copy_only_constants(sorted_constants, known_functions)
     unpacked = xform.unpack_unpacking_assignments(copy_only)
     load_from_store = xform.load_from_store(body, unpacked, known_functions)
 
-    generated = [*load_from_store, *body]
+    generated = [*head, *load_from_store, *body]
     reference = reference_source.body[0].body
 
     ok, diff = check_ast_equals(generated, reference)
@@ -173,6 +173,7 @@ def test_structured_unpacking_transformation():
         pass
     known_functions = {'f': dummy, 'h': dummy}
 
+    head = xform.generate_header()
     body, constants = xform.separate_constants(desc)
     sorted_constants, _ = xform.sort_constants(constants)
     copy_only = xform.copy_only_constants(sorted_constants, known_functions)
@@ -181,24 +182,76 @@ def test_structured_unpacking_transformation():
 
     @xun.function_ast
     def reference_source():
+        _xun_store_accessor = yield
+        yield
         def _xun_load_constants():
             from xun.functions import unpack as _xun_unpack
             from copy import deepcopy as _xun_deepcopy  # noqa: F401
-            from xun.functions import CallNode as _xun_CallNode
-            from xun.functions.store import StoreAccessor as _xun_StoreAccessor
-            _xun_store_accessor = _xun_StoreAccessor(_xun_store)
             a, b, ((x, y, z), (𝛂, β)), c, d = _xun_unpack(
-                (2, ((3,), (2,)), 2),
-                _xun_CallNode('f', 'K9ZuxDD5x6atLkNd')
+                (2, ((3,), (2,)), 2), f()
             )
-            something = _xun_CallNode('h', 'K9ZuxDD5x6atLkNd', x, y, z)
+            something = h(x, y, z)
             return _xun_store_accessor.deepload(
                 a, b, c, d, something, x, y, z, α, β
             )
         a, b, c, d, something, x, y, z, α, β = _xun_load_constants()
         return a * b * x * y * z * 𝛂 * β * c * d + something
 
-    generated = [*load_from_store, *body]
+    generated = [*head, *load_from_store, *body]
+    reference = reference_source.body[0].body
+
+    ok, diff = check_ast_equals(generated, reference)
+    assert ok, diff
+
+
+def test_interface_graph_transformation():
+    @xun.function()
+    def f(arg):
+        return arg
+
+    def g(arg):
+        yield from f(arg * 2)
+
+    desc = xun.describe(g)
+
+    interface_call, target_call = xform.separate_interface_and_target(desc, f)
+    interface = xform.build_interface_graph(interface_call, target_call)
+    generated = [*interface]
+
+    @xun.function_ast
+    def reference_source(arg):
+        import networkx as _xun_nx
+        _xun_graph = _xun_nx.DiGraph()
+        _xun_graph.add_edge(f(arg * 2), g(arg))
+        return _xun_graph
+
+    reference = reference_source.body[0].body
+
+    ok, diff = check_ast_equals(generated, reference)
+    assert ok, diff
+
+
+def test_interface_task_transformation():
+    @xun.function()
+    def f(arg):
+        return arg
+
+    def g(arg):
+        yield from f(arg * 2)
+
+    desc = xun.describe(g)
+
+    interface_call, target_call = xform.separate_interface_and_target(desc, f)
+    interface = xform.interface_raise_on_execution(interface_call, target_call)
+    generated = [*interface]
+
+    @xun.function_ast
+    def reference_source(arg):
+        from xun.functions import XunInterfaceError as _xun_InterfaceError
+        raise _xun_InterfaceError(
+            f'{f(arg * 2)} did not produce a result for {g(arg)}'
+        )
+
     reference = reference_source.body[0].body
 
     ok, diff = check_ast_equals(generated, reference)
@@ -266,5 +319,5 @@ def test_xun_function_to_source():
         value = a + c
         return value
 
-    tree = g.callable().tree
+    tree = g.callable.tree
     assert isinstance(astor.to_source(tree), str)

--- a/xun/tests/test_util.py
+++ b/xun/tests/test_util.py
@@ -8,6 +8,7 @@ from xun.functions import function_source
 from xun.functions.compatibility import ast
 from xun.functions.util import assignment_target_introduced_names
 from xun.functions.util import assignment_target_shape
+from xun.functions.util import call_from_function_definition
 from xun.functions.util import func_external_names
 from xun.functions.util import overwrite_scope
 from xun.functions.util import shape_to_ast_tuple
@@ -230,3 +231,23 @@ def test_assignment_target_introduced_names():
     assert assignment_target_introduced_names(stmts[2]) == {'d', 'e'}
     assert assignment_target_introduced_names(stmts[3]) == {'f', 'g'}
     assert assignment_target_introduced_names(stmts[4]) == {'h'}
+
+
+def test_call_from_function_definition():
+    # Simple example
+    f_def = ast.parse('def f(a, b=1, *args, **kwargs): pass').body[0]
+    expected_call = ast.parse('f(a, b, *args, **kwargs)').body[0].value
+    generated_call = call_from_function_definition(f_def)
+
+    ok, diff = check_ast_equals(generated_call, expected_call)
+    assert ok, diff
+
+    # Advanced example
+    f_def = ast.parse(
+        'def f(a, b, c, d=2, *, e=3, **my_kwargs): pass'
+    ).body[0]
+    expected_call = ast.parse('f(a, b, c, d, e, **my_kwargs)').body[0].value
+    generated_call = call_from_function_definition(f_def)
+
+    ok, diff = check_ast_equals(generated_call, expected_call)
+    assert ok, diff


### PR DESCRIPTION
Introduce a new syntax for storing multiple results from a single
function.

```python
@xun.function()
def f(arg):
    yield even(arg) is arg * 2
    yield odd(arg) is arg * 2 - 1

@f.interface
def even(arg):
    yield from f(arg)

@f.interface
def odd(arg):
    yield from f(arg)
```

The `xun.Function.interface` defines a callable that is reliant on
another function to produce it's result. Which function is specified by
syntax `yield from <call-to-xun-function>`. For example, `yield from f(1)`
indicates that a call to `f(1)` is required to produce a result for the
interface.