### PR TITLE
Retry load on failure for disk stores

### DIFF
--- a/xun/functions/store/disk.py
+++ b/xun/functions/store/disk.py
@@ -3,17 +3,40 @@ from .store import Store
 from collections import namedtuple
 from pathlib import Path
 import contextlib
+import functools
 import shutil
 import tempfile
+import time
 
 
 Paths = namedtuple('Paths', 'key val')
+
+
+def retry(on_exceptions=()):
+    class Decorator:
+        def __init__(self, func):
+            self.func = func
+
+        def __call__(self, retry_delays, instance, *args, **kwargs):
+            for retry_delay in retry_delays:
+                try:
+                    return self.func(instance, *args, **kwargs)
+                except on_exceptions:
+                    time.sleep(retry_delay)
+            return self.func(instance, *args, **kwargs)
+
+        def __get__(self, instance, owner):
+            f = functools.partial(self, instance.retry_delays, instance)
+            functools.update_wrapper(f, self.func)
+            return f
+    return Decorator
 
 
 class Disk(Store):
     def __init__(self, dir, tmpdir=None, create_dirs=True):
         self.dir = Path(dir)
         self.tmpdir = Path(tmpdir) if tmpdir is not None else self.dir
+        self.retry_delays = [0.125, 0.25, 0.5, 1, 2, 4, 8]
         if create_dirs:
             (self.dir / 'keys').mkdir(parents=True, exist_ok=True)
             (self.dir / 'values').mkdir(parents=True, exist_ok=True)
@@ -41,6 +64,7 @@ class Disk(Store):
         return Paths(key=root / 'keys' / key.sha256(),
                      val=root / 'values' / key.sha256())
 
+    @retry(on_exceptions=AssertionError)
     def key_invariant(self, key):
         paths = self.paths(key)
         if self.__contains__(key):
@@ -53,6 +77,7 @@ class Disk(Store):
     def __contains__(self, key):
         return self.paths(key).key.is_file()
 
+    @retry(on_exceptions=(KeyError, FileNotFoundError))
     def _load_value(self, key):
         if __debug__:
             self.key_invariant(key)
@@ -96,10 +121,11 @@ class Disk(Store):
         paths.val.unlink()
 
     def __getstate__(self):
-        return self.dir, self.tmpdir
+        return self.dir, self.tmpdir, self.retry_delays
 
     def __setstate__(self, state):
         self.dir = state[0]
         self.tmpdir = state[1]
+        self.retry_delays = state[2]
         self.dir.mkdir(parents=True, exist_ok=True)
         self.tmpdir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Latency in filesystems might cause files to show up late, failure to
read should be retried